### PR TITLE
Move the random number generation to a dedicated object

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -2,7 +2,8 @@ name: build_linux
 
 on:
   # Enable manual run from the Actions tab
-  workflow_dispatch:
+  - workflow_dispatch
+  - push
 
 jobs:
   build:

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -2,7 +2,8 @@ name: build_osx
 
 on:
   # Enable manual run from the Actions tab
-  workflow_dispatch:
+  - workflow_dispatch
+  - push
 
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,7 +1,8 @@
 name: build_windows
 
 on:
-  workflow_dispatch
+  - workflow_dispatch
+  - push
 
 jobs:
   build:
@@ -15,7 +16,7 @@ jobs:
           $msbuild = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Msbuild\Current\Bin\MSBuild.exe"
           $a = @("muscle.sln", "/p:Platform=x64", "/p:Configuration=Release")
           & $msbuild $a
-          
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@v2
         with:

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -48,14 +48,18 @@ static void Align(MPCFlat &M, MultiSequence &InputSeqs,
 
 void cmd_align()
 	{
-	MWCG rng;
+	MPCFlat M;
+	if (optset_consiters)
+		M.m_ConsistencyIterCount = opt(consiters);
+	if (optset_refineiters)
+		M.m_RefineIterCount = opt(refineiters);
 	uint32_t Seed = 1;
 	if (optset_randseed) {
 		Seed = opt(randseed);
 		if (Seed == 0)
 			Seed = (uint32_t) (time(0)*getpid());
 	}
-	rng.srand(Seed);
+	M.m_rng.srand(Seed);
 
 	MultiSequence InputSeqs;
 	InputSeqs.LoadMFA(opt(align), true);
@@ -75,17 +79,11 @@ void cmd_align()
 	bool OutputWildcard = OutputPattern.find('@') != string::npos;
 	FILE *fOut = 0;
 
-	bool IsNucleo = InputSeqs.GuessIsNucleo(rng);
+	bool IsNucleo = InputSeqs.GuessIsNucleo(m_rng);
 	if (IsNucleo)
 		SetAlpha(ALPHA_Nucleo);
 	else
 		SetAlpha(ALPHA_Amino);
-
-	MPCFlat M;
-	if (optset_consiters)
-		M.m_ConsistencyIterCount = opt(consiters);
-	if (optset_refineiters)
-		M.m_RefineIterCount = opt(refineiters);
 
 	if (opt(stratified) && opt(diversified))
 		Die("Cannot set both -stratified and -diversified");

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -53,10 +53,7 @@ void cmd_align()
 		M.m_ConsistencyIterCount = opt(consiters);
 	if (optset_refineiters)
 		M.m_RefineIterCount = opt(refineiters);
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	M.m_rng.srand(Seed);
+	M.m_rng.srand_opt();
 
 	MultiSequence InputSeqs;
 	InputSeqs.LoadMFA(opt(align), true);

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -19,7 +19,7 @@ void MakeReplicateFileName(const string &Pattern, TREEPERM TP,
 	}
 
 static void Align(MPCFlat &M, MultiSequence &InputSeqs,
-  uint PerturbSeed, RNG& rng, TREEPERM TP, bool WriteEfaHdr, FILE *fOut)
+  uint PerturbSeed, TREEPERM TP, bool WriteEfaHdr, FILE *fOut)
 	{
 	if (fOut == 0)
 		return;
@@ -79,7 +79,7 @@ void cmd_align()
 	bool OutputWildcard = OutputPattern.find('@') != string::npos;
 	FILE *fOut = 0;
 
-	bool IsNucleo = InputSeqs.GuessIsNucleo(m_rng);
+	bool IsNucleo = InputSeqs.GuessIsNucleo(M.m_rng);
 	if (IsNucleo)
 		SetAlpha(ALPHA_Nucleo);
 	else
@@ -121,7 +121,7 @@ void cmd_align()
 		else
 			OutputFileName = OutputPattern;
 		fOut = CreateStdioFile(OutputFileName);
-		Align(M, InputSeqs, PerturbSeed, rng, TP, false, fOut);
+		Align(M, InputSeqs, PerturbSeed, TP, false, fOut);
 		CloseStdioFile(fOut);
 		return;
 		}
@@ -153,7 +153,7 @@ void cmd_align()
 			fOut = CreateStdioFile(OutputFileName);
 			}
 		bool WriteEfaHeader = !OutputWildcard;
-		Align(M, InputSeqs, PerturbSeed, rng, TP, WriteEfaHeader, fOut);
+		Align(M, InputSeqs, PerturbSeed, TP, WriteEfaHeader, fOut);
 		if (OutputWildcard)
 			CloseStdioFile(fOut);
 		}

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -53,12 +53,9 @@ void cmd_align()
 		M.m_ConsistencyIterCount = opt(consiters);
 	if (optset_refineiters)
 		M.m_RefineIterCount = opt(refineiters);
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	M.m_rng.srand(Seed);
 
 	MultiSequence InputSeqs;

--- a/src/alnmsasflat.cpp
+++ b/src/alnmsasflat.cpp
@@ -3,7 +3,7 @@
 
 float AlignMSAsFlat(const string &ProgressStr,
   const MultiSequence &MSA1, const MultiSequence &MSA2,
-  uint TargetPairCount, string &Path)
+  uint TargetPairCount, string &Path, RNG &rng)
 	{
 	const uint SeqCount1 = MSA1.GetNumSequences();
 	const uint SeqCount2 = MSA2.GetNumSequences();
@@ -19,7 +19,7 @@ float AlignMSAsFlat(const string &ProgressStr,
 	vector<uint> SeqIndexes1;
 	vector<uint> SeqIndexes2;
 	GetPairs(SeqCount1, SeqCount2, TargetPairCount,
-	  SeqIndexes1, SeqIndexes2);
+	  SeqIndexes1, SeqIndexes2, rng);
 	const uint PairCount = SIZE(SeqIndexes1);
 	asserta(SIZE(SeqIndexes2) == PairCount);
 

--- a/src/alnmsasflat3.cpp
+++ b/src/alnmsasflat3.cpp
@@ -4,7 +4,7 @@ float AlignMSAsFlat3(const string &ProgressStr,
   const MultiSequence &MSA1, const MultiSequence &MSA2,
   const vector<MySparseMx *> &SparseMxVec,
   uint Index1, uint Index2,
-  uint TargetPairCount, string &Path)
+  uint TargetPairCount, string &Path, RNG &rng)
 	{
 	const uint SeqCount1 = MSA1.GetNumSequences();
 	const uint SeqCount2 = MSA2.GetNumSequences();
@@ -20,7 +20,7 @@ float AlignMSAsFlat3(const string &ProgressStr,
 	vector<uint> SeqIndexes1;
 	vector<uint> SeqIndexes2;
 	GetPairs(SeqCount1, SeqCount2, TargetPairCount,
-	  SeqIndexes1, SeqIndexes2);
+	  SeqIndexes1, SeqIndexes2, rng);
 	const uint PairCount = SIZE(SeqIndexes1);
 	asserta(SIZE(SeqIndexes2) == PairCount);
 

--- a/src/eadistmxmsas.cpp
+++ b/src/eadistmxmsas.cpp
@@ -13,11 +13,7 @@ void cmd_eadistmx_msas()
 	PProg PP;
 	if (optset_paircount)
 		PP.m_TargetPairCount = opt(paircount);
-
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	PP.m_rng.srand(Seed);
+	PP.m_rng.srand_opt();
 
 	bool IsNucleo;
 	PP.LoadMSAs(MSAFileNames, IsNucleo);

--- a/src/eadistmxmsas.cpp
+++ b/src/eadistmxmsas.cpp
@@ -14,12 +14,9 @@ void cmd_eadistmx_msas()
 	if (optset_paircount)
 		PP.m_TargetPairCount = opt(paircount);
 
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	PP.m_rng.srand(Seed);
 
 	bool IsNucleo;

--- a/src/eadistmxmsas.cpp
+++ b/src/eadistmxmsas.cpp
@@ -13,6 +13,15 @@ void cmd_eadistmx_msas()
 	PProg PP;
 	if (optset_paircount)
 		PP.m_TargetPairCount = opt(paircount);
+
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	PP.m_rng.srand(Seed);
+
 	bool IsNucleo;
 	PP.LoadMSAs(MSAFileNames, IsNucleo);
 	SetAlpha(IsNucleo ? ALPHA_Nucleo : ALPHA_Amino);

--- a/src/eesort.cpp
+++ b/src/eesort.cpp
@@ -1,9 +1,19 @@
 #include "muscle.h"
 #include "sort.h"
 #include "locallock.h"
+#include "rng.h"
 
 void cmd_eesort()
 	{
+	MWCG rng;
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	rng.srand(Seed);
+
 	const string &QueryFileName = opt(eesort);
 	const string &DBFileName = opt(db);
 	const string &OutputFileName = opt(output);
@@ -20,7 +30,7 @@ void cmd_eesort()
 	DB.FromFASTA(DBFileName, true);
 	Progress("done\n");
 
-	bool IsNucleo = DB.GuessIsNucleo();
+	bool IsNucleo = DB.GuessIsNucleo(rng);
 	if (IsNucleo)
 		SetAlpha(ALPHA_Nucleo);
 	else

--- a/src/eesort.cpp
+++ b/src/eesort.cpp
@@ -6,10 +6,7 @@
 void cmd_eesort()
 	{
 	MWCG rng;
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	rng.srand(Seed);
+	rng.srand_opt();
 
 	const string &QueryFileName = opt(eesort);
 	const string &DBFileName = opt(db);

--- a/src/eesort.cpp
+++ b/src/eesort.cpp
@@ -6,12 +6,9 @@
 void cmd_eesort()
 	{
 	MWCG rng;
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	rng.srand(Seed);
 
 	const string &QueryFileName = opt(eesort);

--- a/src/ensemble.cpp
+++ b/src/ensemble.cpp
@@ -562,15 +562,15 @@ double Ensemble::GetGapFract(uint Ix) const
 	}
 
 void Ensemble::SubsampleWithReplacement(double MaxGapFract,
-  uint ColCount, MSA &M) const
+  uint ColCount, MSA &M, RNG &rng) const
 	{
 	vector<uint> Ixs;
 	GetIxSubset(MaxGapFract, Ixs);
-	SubsampleWithReplacement(Ixs, ColCount, M);
+	SubsampleWithReplacement(Ixs, ColCount, M, rng);
 	}
 
 void Ensemble::SubsampleWithReplacement(const vector<uint> &Ixs,
-  uint ColCount, MSA &M) const
+  uint ColCount, MSA &M, RNG &rng) const
 	{
 	asserta(ColCount > 0);
 	const uint SeqCount = GetSeqCount();
@@ -586,7 +586,7 @@ void Ensemble::SubsampleWithReplacement(const vector<uint> &Ixs,
 	const uint N = SIZE(Ixs);
 	for (uint i = 0; i < N; ++i)
 		{
-		uint r = randu32()%N;
+		uint r = rng.randu32()%N;
 		uint Ix = Ixs[r];
 		asserta(Ix < SIZE(m_ColumnStrings));
 		const string &ColStr = m_ColumnStrings[Ix];

--- a/src/ensemble.h
+++ b/src/ensemble.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <set>
+#include "rng.h"
 
 class Ensemble
 	{
@@ -57,9 +58,9 @@ public:
 	void GetIxSubset(double MaxGapFract, vector<uint> &Ixs) const;
 	double GetGapFract(uint Ix) const;
 	void SubsampleWithReplacement(double MaxGapFract,
-	  uint ColCount, MSA &M) const;
+	  uint ColCount, MSA &M, RNG &rng) const;
 	void SubsampleWithReplacement(const vector<uint> &Ixs,
-	  uint ColCount, MSA &M) const;
+	  uint ColCount, MSA &M, RNG &rng) const;
 	void GetAbToCountAll(vector<uint> &AbToCount);
 	void GetAbToCount(uint MSAIndex, vector<uint> &AbToCount);
 	uint GetUniqueIx(uint MSAIndex, uint ColIndex) const;

--- a/src/getpairs.cpp
+++ b/src/getpairs.cpp
@@ -31,7 +31,7 @@ void GetAllPairs(uint Count1, uint Count2,
 	}
 
 void GetPairs(uint Count1, uint Count2, uint TargetPairCount,
-  vector<uint> &Indexes1, vector<uint> &Indexes2)
+  vector<uint> &Indexes1, vector<uint> &Indexes2, RNG &rng)
 	{
 	Indexes1.clear();
 	Indexes2.clear();
@@ -48,8 +48,8 @@ void GetPairs(uint Count1, uint Count2, uint TargetPairCount,
 	uint Counter = 0;
 	while (Counter++ < MaxCounter && (uint) SIZE(PairSet) < TargetPairCount)
 		{
-		uint i = randu32()%Count1;
-		uint j = randu32()%Count2;
+		uint i = rng.randu32()%Count1;
+		uint j = rng.randu32()%Count2;
 		if (i == j)
 			continue;
 		pair<uint, uint> Pair(i, j);

--- a/src/mpcflat.cpp
+++ b/src/mpcflat.cpp
@@ -319,11 +319,7 @@ MultiSequence *RunMPCFlat(MultiSequence *InputSeqs)
 		M.m_ConsistencyIterCount = opt(consiters);
 	if (optset_refineiters)
 		M.m_RefineIterCount = opt(refineiters);
-
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	M.m_rng.srand(Seed);
+	M.m_rng.srand_opt();
 
 	TREEPERM TP = TP_None;
 	if (optset_perm)

--- a/src/mpcflat.cpp
+++ b/src/mpcflat.cpp
@@ -320,6 +320,14 @@ MultiSequence *RunMPCFlat(MultiSequence *InputSeqs)
 	if (optset_refineiters)
 		M.m_RefineIterCount = opt(refineiters);
 
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	M.m_rng.srand(Seed);
+
 	TREEPERM TP = TP_None;
 	if (optset_perm)
 		TP = StrToTREEPERM(opt(perm));

--- a/src/mpcflat.cpp
+++ b/src/mpcflat.cpp
@@ -320,12 +320,9 @@ MultiSequence *RunMPCFlat(MultiSequence *InputSeqs)
 	if (optset_refineiters)
 		M.m_RefineIterCount = opt(refineiters);
 
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	M.m_rng.srand(Seed);
 
 	TREEPERM TP = TP_None;

--- a/src/mpcflat.h
+++ b/src/mpcflat.h
@@ -34,6 +34,8 @@ public:
 	vector<MySparseMx *> *m_ptrSparsePosts = &m_SparsePosts1;
 	vector<MySparseMx *> *m_ptrUpdatedSparsePosts = &m_SparsePosts2;
 
+	MWCG m_rng = MWCG();
+
 public:
 	~MPCFlat()
 		{

--- a/src/multisequence.cpp
+++ b/src/multisequence.cpp
@@ -207,7 +207,7 @@ uint MultiSequence::GetSeqIndex(const string &Label, bool FailOnError) const
 	return UINT_MAX;
 	}
 
-bool MultiSequence::GuessIsNucleo() const
+bool MultiSequence::GuessIsNucleo(RNG &rng) const
 	{
 // If at least MIN_NUCLEO_PCT of the first CHAR_COUNT non-gap
 // letters belong to the nucleotide alphabet, guess nucleo.
@@ -219,10 +219,10 @@ bool MultiSequence::GuessIsNucleo() const
 	uint NucleoCount = 0;
 	for (uint i = 0; i < 100; ++i)
 		{
-		uint SeqIndex = randu32()%SeqCount;
+		uint SeqIndex = rng.randu32()%SeqCount;
 		const Sequence &seq = *GetSequence(SeqIndex);
 		const uint L = seq.GetLength();
-		uint r = randu32();
+		uint r = rng.randu32();
 		const uint Pos = r%L;
 		byte c = (byte) GetChar(SeqIndex, Pos);
 		uint Letter = g_CharToLetterNucleo[c];

--- a/src/multisequence.h
+++ b/src/multisequence.h
@@ -2,6 +2,7 @@
 
 #include <set>
 #include "sequence.h"
+#include "rng.h"
 
 class MSA;
 
@@ -125,7 +126,7 @@ public:
 		return BytePtr;
 		}
 
-	bool GuessIsNucleo() const;
+	bool GuessIsNucleo(RNG &rng) const;
 	void LogGSIs(const char *Msg = 0) const;
 	void AssertGSIs() const;
 	void GetLengthOrder(vector<uint> &SeqIndexes) const;
@@ -136,4 +137,3 @@ public:
 	void AssertSeqIds() const;
 #endif
 	};
-

--- a/src/muscle.h
+++ b/src/muscle.h
@@ -31,6 +31,7 @@
 #include "mpcflat.h"
 #include "kmerscan.h"
 #include "alpha3.h"
+#include "rng.h"
 
 #ifndef _WIN32
 #define stricmp strcasecmp
@@ -103,7 +104,7 @@ void LogFlatMx1(const string &Name, const float *Flat, uint LX, uint LY);
 
 float AlignMSAsFlat(const string &aProgressStr,
   const MultiSequence &MSA1, const MultiSequence &MSA2,
-  uint TargetPairCount, string &Path);
+  uint TargetPairCount, string &Path, RNG &rng);
 
 void InitProbcons();
 void AlignMSAsByPath(const MultiSequence &MSA1, const MultiSequence &MSA2,
@@ -130,7 +131,7 @@ void GetAllPairs(uint SeqCount,
 void GetAllPairs(uint SeqCount1, uint SeqCount2,
   vector<uint> &SeqIndexes1, vector<uint> &SeqIndexes2);
 void GetPairs(uint SeqCount1, uint SeqCount2, uint TargetPairCount,
-  vector<uint> &SeqIndexes1, vector<uint> &SeqIndexes2);
+  vector<uint> &SeqIndexes1, vector<uint> &SeqIndexes2, RNG &rng);
 float GetPostPairsAlignedFlat(const string &aProgressStr,
   const MultiSequence &MSA1, const MultiSequence &MSA2,
   const vector<uint> &SeqIndexes1, const vector<uint> &SeqIndexes2, 

--- a/src/muscle.vcxproj
+++ b/src/muscle.vcxproj
@@ -295,6 +295,7 @@
     <ClCompile Include="quarts.cpp" />
     <ClCompile Include="refineflat.cpp" />
     <ClCompile Include="relaxflat.cpp" />
+    <ClCompile Include="rng.cpp" />
     <ClCompile Include="seb8.cpp" />
     <ClCompile Include="sequence.cpp" />
     <ClCompile Include="setprobconsparams.cpp" />
@@ -373,6 +374,7 @@
     <ClInclude Include="qscorer.h" />
     <ClInclude Include="qscorer3.h" />
     <ClInclude Include="quarts.h" />
+    <ClInclude Include="rng.h" />
     <ClInclude Include="scorehistory.h" />
     <ClInclude Include="scoretype.h" />
     <ClInclude Include="seq.h" />

--- a/src/muscle.vcxproj.filters
+++ b/src/muscle.vcxproj.filters
@@ -350,6 +350,9 @@
     <ClCompile Include="eesort.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="rng.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="alpha.h">
@@ -575,6 +578,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="heatmapcolors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="rng.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/myutils.h
+++ b/src/myutils.h
@@ -33,6 +33,8 @@
 #include <map>
 #include <inttypes.h>
 
+#include "rng.h"
+
 // isatty()
 #ifdef	WIN32
 #include <io.h>
@@ -360,9 +362,6 @@ inline bool feq(double x, double y)
 
 #define	memset_zero(a, n)	memset((a), 0, (n)*sizeof(a[0]))
 
-void ResetRand(unsigned Seed);
-unsigned randu32();
-uint64 randu64();
 void Split(const string &Str, vector<string> &Fields, char Sep = '\t');
 void StripWhiteSpace(string &Str);
 bool StartsWith(const string &s, const string &t);
@@ -448,7 +447,7 @@ inline bool myislower(char c) { return (c & 0x20) != 0; }
 bool AccChar(char c);
 void GetAccFromLabel(const string &Label, string &Acc);
 void GetBaseName(const string &PathName, string &BaseName);
-void Shuffle(vector<unsigned> &v);
+void Shuffle(vector<unsigned> &v, RNG &rng);
 
 #define NO_TRACE		0
 #define TMP_TRACE		2	// true but not 1, for grep_trace

--- a/src/perturbhmm.cpp
+++ b/src/perturbhmm.cpp
@@ -1,9 +1,10 @@
 #include "muscle.h"
+#include "rng.h"
 
-static void Perturb(float &P, float Var)
+static void Perturb(float &P, float Var, RNG &rng)
 	{
 	asserta(Var >= 0 && Var < 1);
-	uint Pct = randu32()%100;
+	uint Pct = rng.randu32()%100;
 	float Fract = Pct/100.0f;
 	asserta(Fract >= 0 && Fract <= 1);
 	float Lo = 1.0f - Var;
@@ -14,14 +15,16 @@ static void Perturb(float &P, float Var)
 
 void HMMParams::PerturbProbs(uint Seed)
 	{
+        MWCG rng;
+
 	if (Seed == 0)
 		return;
 
-	ResetRand(Seed);
+	rng.srand(Seed);
 	asserta(m_Var > 0 && m_Var < 1);
 
 	for (uint i = 0; i < SIZE(m_Trans); ++i)
-		Perturb(m_Trans[i], m_Var);
+		Perturb(m_Trans[i], m_Var, rng);
 
 	const uint AlphaSize = GetAlphaSize();
 	for (uint i = 0; i < AlphaSize; ++i)

--- a/src/perturbhmm.cpp
+++ b/src/perturbhmm.cpp
@@ -31,7 +31,7 @@ void HMMParams::PerturbProbs(uint Seed)
 		for (uint j = 0; j <= i; ++j)
 			{
 			float P = m_Emits[i][j];
-			Perturb(P, m_Var);
+			Perturb(P, m_Var, rng);
 			m_Emits[i][j] = P;
 			m_Emits[j][i] = P;
 			}

--- a/src/pprog.cpp
+++ b/src/pprog.cpp
@@ -426,12 +426,9 @@ void cmd_pprog()
 	asserta(MSACount > 1);
 	const string &OutputFileName = opt(output);
 
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	PP.m_rng.srand(Seed);
 
 	PP.m_TargetPairCount = DEFAULT_TARGET_PAIR_COUNT;

--- a/src/pprog.cpp
+++ b/src/pprog.cpp
@@ -245,7 +245,7 @@ void PProg::Run()
 	for (m_JoinIndex = 0; m_JoinIndex < m_JoinCount; ++m_JoinIndex)
 		{
 		ProgressLog("____________________________________________\n");
-		ProgressLog("Join %u/%u, pending %u\n", 
+		ProgressLog("Join %u/%u, pending %u\n",
 		  m_JoinIndex+1, m_JoinCount, SIZE(m_Pending));
 		uint Index1;
 		uint Index2;
@@ -426,10 +426,7 @@ void cmd_pprog()
 	asserta(MSACount > 1);
 	const string &OutputFileName = opt(output);
 
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	PP.m_rng.srand(Seed);
+	PP.m_rng.srand_opt();
 
 	PP.m_TargetPairCount = DEFAULT_TARGET_PAIR_COUNT;
 	if (optset_paircount)

--- a/src/pprog.h
+++ b/src/pprog.h
@@ -26,6 +26,8 @@ public:
 	vector<uint> m_JoinMSAIndexes1;
 	vector<uint> m_JoinMSAIndexes2;
 
+	MWCG m_rng = MWCG();
+
 public:
 	void LoadMSAs(const vector<string> &FileNames, bool &IsNucleo);
 	void SetMSAs(const vector<const MultiSequence *> &MSAs,

--- a/src/pprog2.cpp
+++ b/src/pprog2.cpp
@@ -82,12 +82,9 @@ void cmd_pprog2()
 	vector<string> MSAFileNames;
 	ReadStringsFromFile(opt(pprog2), MSAFileNames);
 
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	PP.m_rng.srand(Seed);
 
 	const uint MSACount = SIZE(MSAFileNames);

--- a/src/pprog2.cpp
+++ b/src/pprog2.cpp
@@ -21,7 +21,7 @@ void PProg::AlignAndJoin(uint Index1, uint Index2)
 	Ps(ProgressStr, "Join %u / %u", m_JoinIndex+1, m_JoinCount);
 
 	string Path;
-	AlignMSAsFlat(ProgressStr, MSA1, MSA2, m_TargetPairCount, Path);
+	AlignMSAsFlat(ProgressStr, MSA1, MSA2, m_TargetPairCount, Path, m_rng);
 
 	string MSALabel12;
 	Ps(MSALabel12, "Join_%u", m_JoinIndex+1);
@@ -81,6 +81,14 @@ void cmd_pprog2()
 	PProg PP;
 	vector<string> MSAFileNames;
 	ReadStringsFromFile(opt(pprog2), MSAFileNames);
+
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	PP.m_rng.srand(Seed);
 
 	const uint MSACount = SIZE(MSAFileNames);
 	asserta(MSACount > 1);

--- a/src/pprog2.cpp
+++ b/src/pprog2.cpp
@@ -82,10 +82,7 @@ void cmd_pprog2()
 	vector<string> MSAFileNames;
 	ReadStringsFromFile(opt(pprog2), MSAFileNames);
 
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	PP.m_rng.srand(Seed);
+	PP.m_rng.srand_opt();
 
 	const uint MSACount = SIZE(MSAFileNames);
 	asserta(MSACount > 1);

--- a/src/pprogt.cpp
+++ b/src/pprogt.cpp
@@ -37,12 +37,9 @@ void cmd_pprogt()
 	if (optset_paircount)
 		PP.m_TargetPairCount = int(opt(paircount));
 
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	PP.m_rng.srand(Seed);
 
 	bool IsNucleo;

--- a/src/pprogt.cpp
+++ b/src/pprogt.cpp
@@ -37,10 +37,7 @@ void cmd_pprogt()
 	if (optset_paircount)
 		PP.m_TargetPairCount = int(opt(paircount));
 
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	PP.m_rng.srand(Seed);
+	PP.m_rng.srand_opt();
 
 	bool IsNucleo;
 	PP.LoadMSAs(MSAFileNames, IsNucleo);

--- a/src/pprogt.cpp
+++ b/src/pprogt.cpp
@@ -37,6 +37,14 @@ void cmd_pprogt()
 	if (optset_paircount)
 		PP.m_TargetPairCount = int(opt(paircount));
 
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	PP.m_rng.srand(Seed);
+
 	bool IsNucleo;
 	PP.LoadMSAs(MSAFileNames, IsNucleo);
 	SetAlpha(IsNucleo ? ALPHA_Nucleo : ALPHA_Amino);

--- a/src/randomchaintree.cpp
+++ b/src/randomchaintree.cpp
@@ -55,10 +55,7 @@ void MPCFlat::CalcGuideTree_RandomChain()
 void cmd_labels2randomchaintree()
 	{
 	MWCG rng;
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	rng.srand(Seed);
+	rng.srand_opt();
 
 	const string &LabelsFileName = opt(labels2randomchaintree);
 	const string &NewickFileName = opt(output);

--- a/src/randomchaintree.cpp
+++ b/src/randomchaintree.cpp
@@ -1,7 +1,8 @@
 #include "muscle.h"
 #include "mpcflat.h"
+#include "rng.h"
 
-static void MakeRandomChainTree(const vector<string> &Labels, Tree &T)
+static void MakeRandomChainTree(const vector<string> &Labels, Tree &T, RNG &rng)
 	{
 	vector<uint> Parents;
 	vector<float> Lengths;
@@ -11,7 +12,7 @@ static void MakeRandomChainTree(const vector<string> &Labels, Tree &T)
 	vector<uint> SeqIndexes;
 	for (uint SeqIndex = 0; SeqIndex < SeqCount; ++SeqIndex)
 		SeqIndexes.push_back(SeqIndex);
-	Shuffle(SeqIndexes);
+	Shuffle(SeqIndexes, rng);
 
 	Parents.resize(2*SeqCount - 1, UINT_MAX);
 	vector<string> NodeLabels;
@@ -48,11 +49,20 @@ static void MakeRandomChainTree(const vector<string> &Labels, Tree &T)
 
 void MPCFlat::CalcGuideTree_RandomChain()
 	{
-	MakeRandomChainTree(m_Labels, m_GuideTree);
+	MakeRandomChainTree(m_Labels, m_GuideTree, m_rng);
 	}
 
 void cmd_labels2randomchaintree()
 	{
+	MWCG rng;
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed):
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	rng.srand(Seed);
+
 	const string &LabelsFileName = opt(labels2randomchaintree);
 	const string &NewickFileName = opt(output);
 
@@ -60,6 +70,6 @@ void cmd_labels2randomchaintree()
 	ReadStringsFromFile(LabelsFileName, Labels);
 
 	Tree T;
-	MakeRandomChainTree(Labels, T);
+	MakeRandomChainTree(Labels, T, rng);
 	T.ToFile(NewickFileName);
 	}

--- a/src/randomchaintree.cpp
+++ b/src/randomchaintree.cpp
@@ -55,12 +55,9 @@ void MPCFlat::CalcGuideTree_RandomChain()
 void cmd_labels2randomchaintree()
 	{
 	MWCG rng;
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	rng.srand(Seed);
 
 	const string &LabelsFileName = opt(labels2randomchaintree);

--- a/src/randomchaintree.cpp
+++ b/src/randomchaintree.cpp
@@ -57,7 +57,7 @@ void cmd_labels2randomchaintree()
 	MWCG rng;
 	uint32_t Seed = 1;
 	if (optset_randseed) {
-		Seed = opt(randseed):
+		Seed = opt(randseed);
 		if (Seed == 0)
 			Seed = (uint32_t) (time(0)*getpid());
 	}

--- a/src/resample.cpp
+++ b/src/resample.cpp
@@ -3,6 +3,15 @@
 
 void cmd_resample()
 	{
+	MWCG rng;
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	rng.srand(Seed);
+
 	const string &FileName = opt(resample);
 	const string &OutputPattern = opt(output);
 	if (OutputPattern.empty())
@@ -47,7 +56,7 @@ void cmd_resample()
 		vector<uint> ResampledUniqueIxs;
 		for (uint i = 0; i < SiteCount; ++i)
 			{
-			uint r = randu32()%N;
+			uint r = rng.randu32()%N;
 			uint UniqueIx = NonGappyUniqueIxs[r];
 			ResampledUniqueIxs.push_back(UniqueIx);
 			}

--- a/src/resample.cpp
+++ b/src/resample.cpp
@@ -4,10 +4,7 @@
 void cmd_resample()
 	{
 	MWCG rng;
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	rng.srand(Seed);
+	rng.srand_opt();
 
 	const string &FileName = opt(resample);
 	const string &OutputPattern = opt(output);

--- a/src/resample.cpp
+++ b/src/resample.cpp
@@ -4,12 +4,9 @@
 void cmd_resample()
 	{
 	MWCG rng;
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	rng.srand(Seed);
 
 	const string &FileName = opt(resample);

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "rng.h"
+
+
+uint32_t SLCG::randu32()
+  {
+  m_state = m_state*214013 + 2531011;
+  return m_state;
+  }
+
+void SLCG::srand(uint32_t Seed)
+  {
+  m_state = Seed;
+  for (int i = 0; i < 10; ++i)
+    randu32();
+  }
+
+
+uint32_t MWCG::randu32()
+  {
+  uint64_t sum = 2111111111*(uint64_t) m_state[3] + 1492*(uint64_t) m_state[2] + 1776*(uint64_t) m_state[1] + 5115*(uint64_t) m_state[0] + m_state[4];
+  m_state[3] = m_state[2];
+  m_state[2] = m_state[1];
+  m_state[1] = m_state[0];
+  m_state[4] = (uint32_t) (sum >> 32);
+  m_state[0] = (uint32_t) sum;
+  return m_state[0];
+  }
+
+void MWCG::srand(uint32_t Seed)
+  {
+  SLCG rng = SLCG();
+  rng.srand(Seed);
+  for (unsigned i = 0; i < 5; i++)
+    m_state[i] = rng.randu32();
+  for (unsigned i = 0; i < 100; i++)
+    randu32();
+  }

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -1,4 +1,12 @@
 #include "rng.h"
+#include "muscle.h"
+
+void RNG::srand_opt()
+  {
+  uint32_t Seed = optd(randseed, 1);
+  if (Seed == 0) Seed = (uint32_t) (time(0)*getpid());
+  srand(Seed);
+  }
 
 
 uint32_t SLCG::randu32()

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "rng.h"
 
 

--- a/src/rng.h
+++ b/src/rng.h
@@ -1,12 +1,21 @@
 #pragma once
 
 #include <stdint.h>
+#include <time.h>
+
+#ifdef	WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 
 // Abstract class for Random Number Generators.
 class RNG
   {
 public:
   virtual uint32_t randu32() = 0;
+  void srand_opt();
   virtual void srand(uint32_t Seed) = 0;
   };
 

--- a/src/rng.h
+++ b/src/rng.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stdint.h>
+
+// Abstract class for Random Number Generators.
+class RNG
+  {
+public:
+  virtual uint32_t randu32() = 0;
+  virtual void srand(uint32_t Seed) = 0;
+  };
+
+// Simple Linear Congruential Generator
+// Bad properties; used just to initialize the better generator.
+// Numerical values used by Microsoft C, according to wikipedia:
+// http://en.wikipedia.org/wiki/Linear_congruential_generator
+class SLCG: public RNG
+  {
+private:
+  uint32_t m_state = 1;
+
+public:
+  SLCG() { srand(1); };
+  SLCG(uint32_t Seed) { srand(Seed); };
+  uint32_t randu32();
+  void srand(uint32_t Seed);
+  };
+
+// A Multiply-With-Carry random number generator, see:
+// http://en.wikipedia.org/wiki/Multiply-with-carry
+// The particular multipliers used here were found on
+// the web where they are attributed to George Marsaglia.
+class MWCG: public RNG
+  {
+private:
+  uint32_t m_state[5];
+public:
+  MWCG() { srand(1); };
+  MWCG(uint32_t Seed) { srand(Seed); };
+  uint32_t randu32();
+  void srand(uint32_t Seed);
+  };

--- a/src/setprobconsparams.cpp
+++ b/src/setprobconsparams.cpp
@@ -29,7 +29,6 @@ void InitProbcons()
 		if (Seed > 0)
 			{
 			ProgressLog("Perturbing HMM parameters with seed %u\n", Seed);
-			ResetRand(Seed);
 			HP.PerturbProbs(Seed);
 			}
 		}

--- a/src/super4.cpp
+++ b/src/super4.cpp
@@ -46,7 +46,7 @@ void Super4::SplitBigMFA_Random(MultiSequence &InputMFA, uint MaxSize,
 		uint RemainingSeqCount = InputSeqCount - OutputSeqCount;
 		if (RemainingSeqCount == 0)
 			break;
-		
+
 		uint N = RemainingSeqCount;
 		if (N > MaxSize)
 			N = MaxSize;
@@ -337,6 +337,15 @@ void Super4::Run(MultiSequence &InputSeqs, TREEPERM TreePerm)
 
 void cmd_super4()
 	{
+	MWCG rng;
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	rng.srand(Seed);
+
 	const string &InputFileName = opt(super4);
 	const string &OutputFileName = opt(output);
 
@@ -347,7 +356,7 @@ void cmd_super4()
 	else if (opt(amino))
 		Nucleo = false;
 	else
-		Nucleo = InputSeqs.GuessIsNucleo();
+		Nucleo = InputSeqs.GuessIsNucleo(rng);
 
 	TREEPERM TP = TP_None;
 	if (optset_perm)

--- a/src/super4.cpp
+++ b/src/super4.cpp
@@ -250,6 +250,11 @@ void Super4::SetOpts()
 	m_MinEAPass2 = (float) optd(super4_minea2, DEFAULT_MIN_EA_SUPER4_PASS2);
 	m_MPC.m_ConsistencyIterCount = optd(consiters, 2);
 	m_MPC.m_RefineIterCount = optd(refineiters, 100);
+        uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
+	m_MPC.m_rng.srand(Seed);
+	m_PP.m_rng.srand(Seed);
 	}
 
 void Super4::CalcConsensusSeqsDistMx()
@@ -338,12 +343,9 @@ void Super4::Run(MultiSequence &InputSeqs, TREEPERM TreePerm)
 void cmd_super4()
 	{
 	MWCG rng;
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	rng.srand(Seed);
 
 	const string &InputFileName = opt(super4);

--- a/src/super4.cpp
+++ b/src/super4.cpp
@@ -250,11 +250,8 @@ void Super4::SetOpts()
 	m_MinEAPass2 = (float) optd(super4_minea2, DEFAULT_MIN_EA_SUPER4_PASS2);
 	m_MPC.m_ConsistencyIterCount = optd(consiters, 2);
 	m_MPC.m_RefineIterCount = optd(refineiters, 100);
-        uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	m_MPC.m_rng.srand(Seed);
-	m_PP.m_rng.srand(Seed);
+	m_MPC.m_rng.srand_opt();
+	m_PP.m_rng.srand_opt();
 	}
 
 void Super4::CalcConsensusSeqsDistMx()
@@ -343,10 +340,7 @@ void Super4::Run(MultiSequence &InputSeqs, TREEPERM TreePerm)
 void cmd_super4()
 	{
 	MWCG rng;
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	rng.srand(Seed);
+	rng.srand_opt();
 
 	const string &InputFileName = opt(super4);
 	const string &OutputFileName = opt(output);

--- a/src/super5.cpp
+++ b/src/super5.cpp
@@ -342,10 +342,7 @@ void Super5::AlignDupes()
 void cmd_super5()
 	{
 	MWCG rng;
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	rng.srand(Seed);
+	rng.srand_opt();
 
 	LoadGlobalInputMS(opt(super5));
 
@@ -411,7 +408,7 @@ void cmd_super5()
 		uint PerturbSeed = 0;
 		if (optset_perturb)
 			PerturbSeed = opt(perturb);
-		
+
 		string OutputFileName;
 		if (OutputPattern.find('@') == string::npos)
 			OutputFileName = OutputPattern;

--- a/src/super5.cpp
+++ b/src/super5.cpp
@@ -223,7 +223,7 @@ void Super5::SetCentroidVecs()
 		bool IsDupe = m_IsDupe[MemberGSI];
 		bool IsMember = m_IsMember[MemberGSI];
 		bool IsCentroid = m_IsCentroid[MemberGSI];
-		
+
 		if (IsDupe || IsMember || IsCentroid)
 			Die("Super5::SetCentroidVecs(), MemberGSI=%u dupe=%c mem=%c cent=%c",
 			   MemberGSI, tof(IsDupe), tof(IsMember), tof(IsCentroid));
@@ -341,6 +341,15 @@ void Super5::AlignDupes()
 
 void cmd_super5()
 	{
+	MWCG rng;
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	rng.srand(Seed);
+
 	LoadGlobalInputMS(opt(super5));
 
 	string &OutputPattern = opt(output);
@@ -358,7 +367,7 @@ void cmd_super5()
 	else if (opt(amino))
 		Nucleo = false;
 	else
-		Nucleo = InputSeqs.GuessIsNucleo();
+		Nucleo = InputSeqs.GuessIsNucleo(rng);
 
 	SetAlpha(Nucleo ? ALPHA_Nucleo : ALPHA_Amino);
 	InitProbcons();

--- a/src/super5.cpp
+++ b/src/super5.cpp
@@ -342,12 +342,9 @@ void Super5::AlignDupes()
 void cmd_super5()
 	{
 	MWCG rng;
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	rng.srand(Seed);
 
 	LoadGlobalInputMS(opt(super5));

--- a/src/uclust.cpp
+++ b/src/uclust.cpp
@@ -180,10 +180,7 @@ void UClust::GetGSIs(
 void cmd_uclust()
 	{
 	MWCG rng;
-	uint32_t Seed = optd(randseed, 1);
-	if (Seed == 0)
-		Seed = (uint32_t) (time(0)*getpid());
-	rng.srand(Seed);
+	rng.srand_opt();
 
 	const string &InputFileName = opt(uclust);
 	const string &OutputFileName = opt(output);

--- a/src/uclust.cpp
+++ b/src/uclust.cpp
@@ -113,7 +113,7 @@ void UClust::Run(MultiSequence &InputSeqs, float MinEA)
 			}
 		else
 			++MemberCount;
-		  
+
 		m_SeqIndexToCentroidSeqIndex[SeqIndex] = RepSeqIndex;
 		}
 	}
@@ -179,6 +179,15 @@ void UClust::GetGSIs(
 
 void cmd_uclust()
 	{
+	MWCG rng;
+	uint32_t Seed = 1;
+	if (optset_randseed) {
+		Seed = opt(randseed);
+		if (Seed == 0)
+			Seed = (uint32_t) (time(0)*getpid());
+	}
+	rng.srand(Seed);
+
 	const string &InputFileName = opt(uclust);
 	const string &OutputFileName = opt(output);
 	const float MinPctId = (float) optd(pctid, 90);
@@ -186,7 +195,7 @@ void cmd_uclust()
 	MultiSequence InputSeqs;
 	InputSeqs.FromFASTA(InputFileName);
 
-	bool IsNucleo = InputSeqs.GuessIsNucleo();
+	bool IsNucleo = InputSeqs.GuessIsNucleo(rng);
 	if (IsNucleo)
 		SetAlpha(ALPHA_Nucleo);
 	else

--- a/src/uclust.cpp
+++ b/src/uclust.cpp
@@ -180,12 +180,9 @@ void UClust::GetGSIs(
 void cmd_uclust()
 	{
 	MWCG rng;
-	uint32_t Seed = 1;
-	if (optset_randseed) {
-		Seed = opt(randseed);
-		if (Seed == 0)
-			Seed = (uint32_t) (time(0)*getpid());
-	}
+	uint32_t Seed = optd(randseed, 1);
+	if (Seed == 0)
+		Seed = (uint32_t) (time(0)*getpid());
 	rng.srand(Seed);
 
 	const string &InputFileName = opt(uclust);


### PR DESCRIPTION
Hello Robert!

A little introduction first: I'm a PhD student in bioinformatics and I spend my (little) spare time bringing more biological software into Python, to make it easier and safer for newbie bioinformaticians to build more complex pipelines. I developed [Pyrodigal](https://github.com/althonos/pyrodigal), [PyHMMER](https://github.com/althonos/pyhmmer) and [PyFastANI](https://github.com/althonos/pyfastani), which are Python bindings to a statically compiled version of respectively Prodigal, HMMER3 and FastANI. 

I was successful in building and wrapping MUSCLE v5 in an Python extension (see [althonos/pymuscle5](https://github.com/althonos/pymuscle5)). At the moment, it can replicate results from a `muscle -align` invocation and interface with `Sequence` and `MSA` types through Python code. I also replaced the OpenMP-based parallelization with the Python one (using a `ThreadPool` from the standard library), which should be easier for porting across platforms.

However, because the random number generation in the current MUSCLE code is done globally, this makes parallel runs inconsistent because they will affect the global generator. The solution proposed here, also done in HMMER, is to have a dedicated Random Number Generator class, and local objects for each alignment. This way, you can run several `MPCFlat` instances in parallel in the same process.  I've tested `muscle -align` on some test files and got similar results, but maybe you'd want to setup a more comprehensive test case.

_I'll probably make similar PRs later on with other aspects like alphabet and HMM params if you're okay with it, so that it's easier to use from the library code._

