### PR TITLE
Update workflow for portable macOS binary (remove need to install gcc@11), fixes #21

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -22,6 +22,10 @@ jobs:
           ls -lh
           cd src
           make LDFLAGS2=-static
+      - name: Check linking
+        run: |
+          echo "Checking for dylib linking"
+          ldd $GITHUB_WORKSPACE/src/Linux/muscle || true
       - name: Upload binary artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -17,11 +17,21 @@ jobs:
         run: |
           echo Starting Build-commands
           echo GITHUB_WORKSPACE=$GITHUB_WORKSPACE
+          ls -lh $GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE/src
+
+          # What system are we on?
           uname -a
-          cd $GITHUB_WORKSPACE
-          ls -lh
-          cd src
-          LDFLAGS="-static" make
+
+          # Which compiler is being called from make (unless overridden below)?
+          MAKECXXVAR=$( {(make -n -p | grep -e '^CXX =') 2>/dev/null;} | tr -d '[:space:]' )
+          (echo $MAKECXXVAR && eval export "${MAKECXXVAR}" && $CXX --version)
+          echo "${CXX}"
+
+          # Build
+          env LDFLAGS="-static" \
+              make
+
       - name: Check linking
         run: |
           echo "Checking for dylib linking"

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -21,7 +21,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           ls -lh
           cd src
-          make LDFLAGS2=-static
+          LDFLAGS="-static" make
       - name: Check linking
         run: |
           echo "Checking for dylib linking"

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -26,6 +26,10 @@ jobs:
         run: |
           echo "Checking for dylib linking"
           ldd $GITHUB_WORKSPACE/src/Linux/muscle || true
+      - name: Check execution
+        run: |
+          chmod +x $GITHUB_WORKSPACE/src/Linux/muscle
+          $GITHUB_WORKSPACE/src/Linux/muscle -h
       - name: Upload binary artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -18,11 +18,21 @@ jobs:
         run: |
           echo Starting Build-commands
           echo GITHUB_WORKSPACE=$GITHUB_WORKSPACE
+          ls -lh $GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE/src
+
+          # What system are we on?
           uname -a
-          cd $GITHUB_WORKSPACE
-          ls -lh
-          cd src
-          CXX=g++-11 make
+
+          # Which compiler is being called from make (unless overridden below)?
+          MAKECXXVAR=$( {(make -n -p | grep -e '^CXX =') 2>/dev/null;} | tr -d '[:space:]' )
+          (echo $MAKECXXVAR && eval export "${MAKECXXVAR}" && $CXX --version)
+          echo "${CXX}"
+
+          # Build
+          env CXX=g++-11 \
+              make
+
       - name: Check linking
         run: |
           echo "Checking for dylib linking"

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -22,7 +22,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           ls -lh
           cd src
-          make
+          CXX=g++-11 make
       - name: Check linking
         run: |
           echo "Checking for dylib linking"

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           echo "Checking for dylib linking"
           otool -L $GITHUB_WORKSPACE/src/Darwin/muscle
+      - name: Check execution
+        run: |
+          chmod +x $GITHUB_WORKSPACE/src/Darwin/muscle
+          $GITHUB_WORKSPACE/src/Darwin/muscle -h
       - name: Upload binary artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -32,10 +32,11 @@ jobs:
           # On Darwin, LDFLAGS will be read by apple-ld. This doesn't let you do Bstatic or similar tricks.
           # You have to _specifically_ choose the static library location.
           # Thankfully GitHub runner allows us to call brew,
-          #   so we can get the location of the required libraries.
-          env CXX=g++-11 \
-              LDFLAGS="-static-libstdc++" \
-              LIBS="$(brew --prefix gcc@11)/lib/gcc/11/libstdc++.a $(brew --prefix gcc@11)/lib/gcc/11/libgomp.a" \
+          #   so we can install libomp (LLVM's openmp library) if it isn't already,
+          #   and statically link against it.
+          brew install libomp
+          env CXXFLAGS="-I$(brew --prefix libomp)/include" \
+              LIBS="$(brew --prefix libomp)/lib/libomp.a" \
               make
 
       - name: Check linking

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -31,6 +31,7 @@ jobs:
 
           # Build
           env CXX=g++-11 \
+              LIBS="-Wl,-Bstatic -lgomp -Wl,-Bdynamic" \
               make
 
       - name: Check linking

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -23,6 +23,10 @@ jobs:
           ls -lh
           cd src
           make
+      - name: Check linking
+        run: |
+          echo "Checking for dylib linking"
+          otool -L $GITHUB_WORKSPACE/src/Darwin/muscle
       - name: Upload binary artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -29,9 +29,13 @@ jobs:
           (echo $MAKECXXVAR && eval export "${MAKECXXVAR}" && $CXX --version)
           echo "${CXX}"
 
-          # Build
+          # On Darwin, LDFLAGS will be read by apple-ld. This doesn't let you do Bstatic or similar tricks.
+          # You have to _specifically_ choose the static library location.
+          # Thankfully GitHub runner allows us to call brew,
+          #   so we can get the location of the required libraries.
           env CXX=g++-11 \
-              LIBS="-Wl,-Bstatic -lgomp -Wl,-Bdynamic" \
+              LDFLAGS="-static-libstdc++" \
+              LIBS="$(brew --prefix gcc@11)/lib/gcc/11/libstdc++.a $(brew --prefix gcc@11)/lib/gcc/11/libgomp.a" \
               make
 
       - name: Check linking

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ CPPFLAGS += -DNDEBUG -pthread
 CPPFLAGS += -fopenmp
 
 # Add default flags
-CXXFLAGS += -O3 -ffast-math
+CXXFLAGS += -O3 -ffast-math -std=c++11
 LDFLAGS += -O3 -pthread -lpthread -fopenmp
 
 HDRS := $(shell echo *.h)

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,9 +27,21 @@ else
 	CPPFLAGS += -fopenmp
 endif
 
+# If Darwin, then -fopenmp won't work in linker stage appropriately.
+# (Apple-ld is picky.)
+# As such, the user must specify an OpenMP implementation in LIBS.
+# We check this (quick-and-dirty) to help them out.
+ifneq '' '$(findstring Darwin, $(OS))'
+	ifeq '' '$(findstring omp, $(LIBS))'
+		maybe_missing_omp=1
+	endif
+else
+	LDFLAGS += -fopenmp
+endif
+
 # Add default flags
 CXXFLAGS += -O3 -ffast-math -std=c++11
-LDFLAGS += -O3 -pthread -lpthread -fopenmp
+LDFLAGS += -O3 -pthread -lpthread
 
 HDRS := $(shell echo *.h)
 OBJS := $(shell echo *.cpp | sed "-es/^/$(OS)\//" | sed "-es/ / $(OS)\//g" | sed "-es/\.cpp/.o/g")
@@ -39,7 +51,11 @@ SRCS := $(shell ls *.cpp *.h)
 .PHONY: clean
 
 $(OS)/muscle : gitver.txt $(OS)/ $(OBJS)
-	$(CXX) $(LDFLAGS) $(OBJS) -o $@
+	@if [ -n "${maybe_missing_omp}" ]; then \
+		echo "Warning: please specify an OpenMP library in LIBS."; \
+	fi
+
+	$(CXX) $(LDFLAGS) $(LIBS) $(OBJS) -o $@
 
 	@# Warning: do not add -d option to strip, this is not portable
 	strip $(OS)/muscle

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,16 +17,17 @@
 
 OS := $(shell uname)
 
-CPPFLAGS := $(CPPFLAGS) -DNDEBUG -pthread
+CPPFLAGS += -DNDEBUG -pthread
+CPPFLAGS += -fopenmp
 
-
-CXXFLAGS := $(CXXFLAGS) -O3 -fopenmp -ffast-math
-
-LDFLAGS := $(LDFLAGS) -O3 -fopenmp -pthread -lpthread ${LDFLAGS2}
+# Add default flags
+CXXFLAGS += -O3 -ffast-math
+LDFLAGS += -O3 -pthread -lpthread -fopenmp
 
 HDRS := $(shell echo *.h)
 OBJS := $(shell echo *.cpp | sed "-es/^/$(OS)\//" | sed "-es/ / $(OS)\//g" | sed "-es/\.cpp/.o/g")
 SRCS := $(shell ls *.cpp *.h)
+
 
 .PHONY: clean
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,7 @@ SRCS := $(shell ls *.cpp *.h)
 $(OS)/muscle : gitver.txt $(OS)/ $(OBJS)
 	$(CXX) $(LDFLAGS) $(OBJS) -o $@
 
-	# Warning: do not add -d option to strip, this is not portable
+	@# Warning: do not add -d option to strip, this is not portable
 	strip $(OS)/muscle
 
 gitver.txt : $(SRCS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,14 @@
 OS := $(shell uname)
 
 CPPFLAGS += -DNDEBUG -pthread
-CPPFLAGS += -fopenmp
+
+# Detect if CXX is Apple clang, use custom preprocessor call
+COMPILER_VERSION := $(shell $(CXX) --version)
+ifneq '' '$(findstring Apple clang, $(COMPILER_VERSION))'
+	CPPFLAGS += -Xpreprocessor -fopenmp
+else
+	CPPFLAGS += -fopenmp
+endif
 
 # Add default flags
 CXXFLAGS += -O3 -ffast-math -std=c++11

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,10 +19,6 @@ OS := $(shell uname)
 
 CPPFLAGS := $(CPPFLAGS) -DNDEBUG -pthread
 
-CXX := g++
-ifeq ($(OS),Darwin)
-	CXX := g++-11
-endif
 
 CXXFLAGS := $(CXXFLAGS) -O3 -fopenmp -ffast-math
 

--- a/src/gitver.bash
+++ b/src/gitver.bash
@@ -11,12 +11,7 @@ fi
 PATH=$PATH:/usr/bin
 
 git describe --abbrev=6 --dirty --long --always \
-  > gitver.tmp
-
-sed -i '-es/"//g' gitver.tmp
-
-echo \"`cat gitver.tmp`\" > gitver.txt
-
-rm -f gitver.tmp
+  | sed -e 's/\(.*\)/"\1"/' \
+  > gitver.txt
 
 cat gitver.txt


### PR DESCRIPTION
Here's (finally) some changes that alter the GitHub workflow to generate a portable macOS binary.
By portable, I mean that it has dynamic links to only libc++.1.dylib and libSystem.B.dylib: I _believe_ these libraries are bundled with all macOS distributions since 10.9 (when Apple switched from gcc to clang).

The workflow.yml for macOS and Linux now also print some more data as the runner builds the artifact --- this helped me work out what was going on in the runner as I was making changes. IMO, this should aid in future debugging of runners.

This commit history does include a bunch of (failed) attempts to continue using the GNU compilers on macOS. I'm unsure if including the dead-ends is useful & illustrative for anyone, it's mostly cathartic for me.

I've tested the compiled binary on a macOS 12.3 machine of mine that doesn't have g++-11 installed. An alignment with the default settings looks fine, and shows an expected multithreading speedup vs `-threads 1`.

Feel free to request changes / comment on things you'd like more explanation for, Robert!
(Commit messages also contain more info).