### PR TITLE
fix compile error for unknown target

### DIFF
--- a/src/myutils.cpp
+++ b/src/myutils.cpp
@@ -1101,6 +1101,10 @@ double GetPhysMemBytes()
 	return double(mempages);
 	}
 #else
+double GetPhysMemBytes()
+	{
+	return 100000000; // 100M for unknown system
+	}
 double GetMemUseBytes()
 	{
 	return 0.0;


### PR DESCRIPTION
Hello Robert~

   If compile  to ```unknown target(example: webassembly)```, need add a fake ```GetPhysMemBytes``` then will work~