### PR TITLE
Add support for aarch64 architecture in myutils.h

### DIFF
--- a/src/myutils.h
+++ b/src/myutils.h
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include "myalloc.h"
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__arm64__)
+#if defined(__x86_64__) || defined(_M_X64) || defined(__arm64__) || defined(__aarch64__)
 #define	BITS			64
 #else
 #define	BITS			32


### PR DESCRIPTION
This fixes a runtime error (when original code is used for compilation on aarch64):
```---Fatal error---
myutils.cpp(106) assert failed: sizeof(void *) == 4```